### PR TITLE
deprecate fortiosapi code

### DIFF
--- a/ansible_templates/code.j2
+++ b/ansible_templates/code.j2
@@ -2,22 +2,8 @@
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 from ansible_collections.fortinet.fortios.plugins.module_utils.fortios.fortios import FortiOSHandler
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortios.fortios import check_legacy_fortiosapi
 from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
-
-
-def login(data, fos):
-    host = data['host']
-    username = data['username']
-    password = data['password']
-    ssl_verify = data['ssl_verify']
-
-    fos.debug('on')
-    if 'https' in data and not data['https']:
-        fos.https('off')
-    else:
-        fos.https('on')
-
-    fos.login(host, username, password, verify=ssl_verify)
 
 
 def filter_{{path}}_{{name}}_data(json):
@@ -317,13 +303,8 @@ str
 {%- endmacro %}
 def main():
     fields = {
-        "host": {"required": False, "type": "str"},
-        "username": {"required": False, "type": "str"},
-        "password": {"required": False, "type": "str", "default": "", "no_log": True},
         "access_token": {"required": False, "type": "str", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
-        "https": {"required": False, "type": "bool", "default": True},
-        "ssl_verify": {"required": False, "type": "bool", "default": True},
         {%if "mkey" in schema['schema'] %}"state": {"required": {% if module_version_added == 2.8 %}False{% else %}True{% endif %}, "type": "str",
                         "choices": ["present", "absent"]},
         {%endif-%}
@@ -337,46 +318,26 @@ def main():
         }
     }
 
+    check_legacy_fortiosapi()
     module = AnsibleModule(argument_spec=fields,
                            supports_check_mode={% if supports_check_mode %}True{% else %}False{% endif %})
 
-    # legacy_mode refers to using fortiosapi instead of HTTPAPI
-    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
-                  'username' in module.params and module.params['username'] is not None and \
-                  'password' in module.params and module.params['password'] is not None
-
     versions_check_result = None
-    if not legacy_mode:
-        if module._socket_path:
-            connection = Connection(module._socket_path)
-            if 'access_token' in module.params:
-                connection.set_option('access_token', module.params['access_token'])
+    if module._socket_path:
+        connection = Connection(module._socket_path)
+        if 'access_token' in module.params:
+            connection.set_option('access_token', module.params['access_token'])
 
-            fos = FortiOSHandler(connection)
+        fos = FortiOSHandler(connection)
 
-            {% if supports_check_mode -%}
-            is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode)
-            {% else -%}
-            is_error, has_changed, result = fortios_{{path}}(module.params, fos)
-            {% endif -%}
-            versions_check_result = connection.get_system_version()
-        else:
-            module.fail_json(**FAIL_SOCKET_MSG)
-    else:
-        try:
-            from fortiosapi import FortiOSAPI
-        except ImportError:
-            module.fail_json(msg="fortiosapi module is required")
-
-        fos = FortiOSAPI()
-
-        login(module.params, fos)
         {% if supports_check_mode -%}
         is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode)
         {% else -%}
         is_error, has_changed, result = fortios_{{path}}(module.params, fos)
         {% endif -%}
-        fos.logout()
+        versions_check_result = connection.get_system_version()
+    else:
+        module.fail_json(**FAIL_SOCKET_MSG)
 
     if versions_check_result and versions_check_result['matched'] is False:
         module.warn("Ansible has detected version mismatch between FortOS system and galaxy, see more details by specifying option -vvv")

--- a/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
+++ b/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
@@ -38,7 +38,8 @@ import traceback
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
-
+from ansible.module_utils.basic import _load_params
+import sys
 import json
 
 try:
@@ -86,6 +87,18 @@ fortios_error_codes = {
     '-61': "Command error"
 }
 
+
+def check_legacy_fortiosapi():
+    params = _load_params()
+    legacy_schemas = ['host', 'username', 'password', 'ssl_verify', 'https']
+    legacy_params = []
+    for param in legacy_schemas:
+        if param in params:
+            legacy_params.append(param)
+    if len(legacy_params):
+        error_message = 'Legacy fortiosapi parameters %s detected, please use HTTPAPI instead!' % (str(legacy_params))
+        sys.stderr.write(error_message)
+        sys.exit(1)
 # END DEPRECATED
 
 

--- a/scripts/ansible_collection_path.py
+++ b/scripts/ansible_collection_path.py
@@ -1,0 +1,10 @@
+#! /usr/bin/python3
+import sys
+try:
+    import ansible_collections
+except:
+    sys.exit(1)
+
+for i in ansible_collections.__path__:
+    print(i[:-(len('ansible_collections') + 1)], end='')
+    break

--- a/scripts/generate_doc
+++ b/scripts/generate_doc
@@ -5,6 +5,13 @@
 mkdir -p galaxy_output/ansible_collections/fortinet/fortios
 ln -s `pwd`/galaxy_templates/collection/plugins `pwd`/galaxy_output/ansible_collections/fortinet/fortios  2>/dev/null
 
+sys_ansible_collection_path=`python3 ./scripts/ansible_collection_path.py`
+sys_ansible_collection_found=$?
+
+if [ $sys_ansible_collection_found -eq 0 ]; then
+    mv -f $sys_ansible_collection_path/ansible_collections $sys_ansible_collection_path/ansible_collections.bak
+fi
+
 version=$(get_schema_version)
 echo "generating online document $version"
 
@@ -18,3 +25,7 @@ do
     python3 ./scripts/generate_doc.py $f $docfile
     #cp $docfile /root/tmp/ansible-collection-sphinx/docgen
 done
+
+if [ $sys_ansible_collection_found -eq 0 ]; then
+    mv -f $sys_ansible_collection_path/ansible_collections.bak $sys_ansible_collection_path/ansible_collections
+fi


### PR DESCRIPTION
remove all legacy fortiosapi code.

if any legacy parameters are given, ansible module will prompt error message to remind you that fortiosapi is deprecated. e.g.
```
$cat global_attribute.yml
- hosts: fortigate03
  connection: httpapi
  collections:
  - fortinet.fortios
  vars:
   vdom: "root"
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
   - name: Configure global attributes.
     fortios_firewall_address:
        https: true
        host: '23.2.2.3'
        vdom:  "{{ vdom }}"
        state: "present"
        access_token: "{{ fortios_access_token }}"
        firewall_address:
            name: 'FW/ADDRESS?! with escape letters'
```

then run it:
```
.....
fatal: [fortigate03]: FAILED! => {
    "changed": false,
    "module_stderr": "Legacy fortiosapi parameters ['host', 'https'] detected, please use HTTPAPI instead!",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

.....

```

@JieX19 .

Thanks,
Link