### PR TITLE
predefine mkey name to avoid fetching schema during runtime

### DIFF
--- a/ansible_templates/code.j2
+++ b/ansible_templates/code.j2
@@ -302,6 +302,7 @@ str
                 {% endfor -%}
 {%- endmacro %}
 def main():
+    mkeyname = {% if mkeyname -%} '{{mkeyname}}' {%- else -%} None {%- endif %}
     fields = {
         "access_token": {"required": False, "type": "str", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
@@ -328,7 +329,7 @@ def main():
         if 'access_token' in module.params:
             connection.set_option('access_token', module.params['access_token'])
 
-        fos = FortiOSHandler(connection)
+        fos = FortiOSHandler(connection, mkeyname)
 
         {% if supports_check_mode -%}
         is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode)

--- a/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
+++ b/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
@@ -57,19 +57,6 @@ try:
 except ImportError:
     HAS_PYFG = False
 
-fortios_argument_spec = dict(
-    file_mode=dict(type='bool', default=False),
-    config_file=dict(type='path'),
-    host=dict(),
-    username=dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
-    password=dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
-    timeout=dict(type='int', default=60),
-    vdom=dict(type='str'),
-    backup=dict(type='bool', default=False),
-    backup_path=dict(type='path'),
-    backup_filename=dict(type='str'),
-)
-
 fortios_required_if = [
     ['file_mode', False, ['host', 'username', 'password']],
     ['file_mode', True, ['config_file']],
@@ -104,8 +91,9 @@ def check_legacy_fortiosapi():
 
 class FortiOSHandler(object):
 
-    def __init__(self, conn):
+    def __init__(self, conn, module_mkeyname=None):
         self._conn = conn
+        self._mkeyname = module_mkeyname
 
     def cmdb_url(self, path, name, vdom=None, mkey=None):
 
@@ -147,12 +135,7 @@ class FortiOSHandler(object):
             return json.loads(to_text(result_data))
 
     def get_mkeyname(self, path, name, vdom=None):
-        schema = self.schema(path, name, vdom=vdom)
-        try:
-            keyname = schema['mkey']
-        except KeyError:
-            return False
-        return keyname
+        return self._mkeyname
 
     def get_mkey(self, path, name, data, vdom=None):
 

--- a/scripts/generate_modules.py
+++ b/scripts/generate_modules.py
@@ -133,6 +133,10 @@ def renderModule(schema, version, special_attributes, valid_identifiers, version
     #    print("cannot find", module_name)
     #    return
 
+    mkeyname = None
+    if 'mkey' in schema['schema']:
+        mkeyname = schema['schema']['mkey']
+
     special_attributes_flattened = [','.join(x for x in elem) for elem in special_attributes]
 
     template = env.get_template('doc.j2')


### PR DESCRIPTION
issuing an `GET` request with `action=schema` is not necessary during runtime. 
so we are to remove it, reducing time to complete a task.
 

@JieX19 