### PR TITLE
Resolves issue with missing `State` options

### DIFF
--- a/ansible_templates/code.j2
+++ b/ansible_templates/code.j2
@@ -123,9 +123,9 @@ def is_same_comparison(reorder_current, reorder_filtered):
 {% endif -%}
 
 {% if supports_check_mode -%}
-def {{path}}_{{name}}(data, fos, check_mode=False):
+def {{path}}_{{name}}(data, fos, check_mode=False, module):
 {% else -%}
-def {{path}}_{{name}}(data, fos):
+def {{path}}_{{name}}(data, fos, module):
 {%- endif %}
     vdom = data['vdom']
     {%- if "mkey" in schema['schema'] %}
@@ -135,6 +135,7 @@ def {{path}}_{{name}}(data, fos):
         state = data['{{path}}_{{name}}']['state']
     else:
         state = True{% else %}state = data['state']{% endif %}
+        module.warn("state was not provided. Assuming 'present'.")
     {%- endif %}
     {{path}}_{{name}}_data = data['{{path}}_{{name}}']
     {% if special_attributes != [] -%}{{path}}_{{name}}_data = flatten_multilists_attributes({{path}}_{{name}}_data)
@@ -154,7 +155,7 @@ def {{path}}_{{name}}(data, fos):
             and len(current_data['results']) > 0
 
         # 2. if it exists and the state is 'present' then compare current settings with desired
-        if state == 'present':
+        if state == 'present' or state == True:
             if mkey is None:
                 return False, True, filtered_data
 
@@ -179,7 +180,7 @@ def {{path}}_{{name}}(data, fos):
         return True, False, {'reason: ': 'Must provide state parameter'}
     {% endif -%}
     {% if "mkey" in schema['schema'] %}
-    if state == "present":
+    if state == "present" or state == True:
         return fos.set('{{original_path}}',
                        '{{original_name}}',
                        {% if vi|length > 0 -%}
@@ -370,9 +371,9 @@ def main():
         fos = FortiOSHandler(connection, module, mkeyname)
 
         {% if supports_check_mode -%}
-        is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode)
+        is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode, module)
         {% else -%}
-        is_error, has_changed, result = fortios_{{path}}(module.params, fos)
+        is_error, has_changed, result = fortios_{{path}}(module.params, fos, module)
         {% endif -%}
         versions_check_result = connection.get_system_version()
     else:

--- a/ansible_templates/code.j2
+++ b/ansible_templates/code.j2
@@ -123,9 +123,9 @@ def is_same_comparison(reorder_current, reorder_filtered):
 {% endif -%}
 
 {% if supports_check_mode -%}
-def {{path}}_{{name}}(data, fos, check_mode=False, module):
+def {{path}}_{{name}}(data, fos, check_mode=False):
 {% else -%}
-def {{path}}_{{name}}(data, fos, module):
+def {{path}}_{{name}}(data, fos):
 {%- endif %}
     vdom = data['vdom']
     {%- if "mkey" in schema['schema'] %}
@@ -134,8 +134,9 @@ def {{path}}_{{name}}(data, fos, module):
     elif 'state' in data['{{path}}_{{name}}'] and data['{{path}}_{{name}}']['state']:
         state = data['{{path}}_{{name}}']['state']
     else:
-        state = True{% else %}state = data['state']{% endif %}
-        module.warn("state was not provided. Assuming 'present'.")
+        state = True{% else %}state = data['state']
+        fos._module.warn("state was not provided. Assuming 'present'."){% endif %}
+        
     {%- endif %}
     {{path}}_{{name}}_data = data['{{path}}_{{name}}']
     {% if special_attributes != [] -%}{{path}}_{{name}}_data = flatten_multilists_attributes({{path}}_{{name}}_data)
@@ -371,9 +372,9 @@ def main():
         fos = FortiOSHandler(connection, module, mkeyname)
 
         {% if supports_check_mode -%}
-        is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode, module)
+        is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode)
         {% else -%}
-        is_error, has_changed, result = fortios_{{path}}(module.params, fos, module)
+        is_error, has_changed, result = fortios_{{path}}(module.params, fos)
         {% endif -%}
         versions_check_result = connection.get_system_version()
     else:


### PR DESCRIPTION
* Include `module` in the function, so we can use `module.warn` when `state` is not defined.
* Assume `state: present`

This PR replaces #17 which was based on the wrong branch.