### PR TITLE
Improved "selector" listing

### DIFF
--- a/ansible_templates/configuration_fact.rst.j2
+++ b/ansible_templates/configuration_fact.rst.j2
@@ -44,8 +44,10 @@ Parameters
         </h2>
         <div class="content">
         <ul class="ul-self">
-        {% for selector in selectors -%}
+        {% for selector in selectors | dictsort(false) -%}
+          {% if 'diagnose__' not in selector and 'execute__' not in selector %}
             <li><span class="li-normal">{{selector}}</span> {% if selectors[selector]['mkey'] %} <span class="li-required">param: {{ selectors[selector]['mkey'] }}</span>  <span class="li-required">type: {{ selectors[selector]['mkey_type'] }}</span>{% endif%}</li>
+          {% endif -%}
         {% endfor -%}
         </ul>
         </div>


### PR DESCRIPTION
Not entirely sure this does what I want, but the selector list contains non-usable items, like:

* `execute__tree__.backup.memory.alllogs_tftp`
* `diagnose__tree__.ipv6.router_rip`

Neither of these are usable in the fortios_configuration_fact module.

Also, this sorts the list into order... in theory ;)

I haven't tested it yet, as it's a bit of a last-minute commit :)