### PR TITLE
Backport: Sort selector into alphabetical order

### DIFF
--- a/ansible_templates/configuration_fact.rst.j2
+++ b/ansible_templates/configuration_fact.rst.j2
@@ -44,8 +44,14 @@ Parameters
         </h2>
         <div class="content">
         <ul class="ul-self">
+        {% set ns = namespace(selectors=[]) -%}
         {% for selector in selectors -%}
-            <li><span class="li-normal">{{selector}}</span> {% if selectors[selector]['mkey'] %} <span class="li-required">param: {{ selectors[selector]['mkey'] }}</span>  <span class="li-required">type: {{ selectors[selector]['mkey_type'] }}</span>{% endif%}</li>
+        {% set ns.selectors = ns.selectors + [selector] -%}
+        {% endfor -%}
+        {% for selector in ns.selectors | sort -%}
+        {% if 'diagnose__' not in selector and 'execute__' not in selector -%}
+        <li><span class="li-normal">{{selector}}</span> {% if selectors[selector]['mkey'] %} <span class="li-required">param: {{ selectors[selector]['mkey'] }}</span>  <span class="li-required">type: {{ selectors[selector]['mkey_type'] }}</span>{% endif%}</li>
+        {% endif -%}
         {% endfor -%}
         </ul>
         </div>


### PR DESCRIPTION
backport https://github.com/fortinet-ansible-dev/fortios-ansible-generator/pull/21 to `feature/1.x`