### PR TITLE
Added code to check schema/parameter diff at runtime

### DIFF
--- a/ansible_templates/code.j2
+++ b/ansible_templates/code.j2
@@ -4,6 +4,7 @@ from ansible.module_utils.connection import Connection
 from ansible_collections.fortinet.fortios.plugins.module_utils.fortios.fortios import FortiOSHandler
 from ansible_collections.fortinet.fortios.plugins.module_utils.fortios.fortios import check_legacy_fortiosapi
 from ansible_collections.fortinet.fortios.plugins.module_utils.fortios.fortios import schema_to_module_spec
+from ansible_collections.fortinet.fortios.plugins.module_utils.fortios.fortios import check_schema_versioning
 from ansible_collections.fortinet.fortios.plugins.module_utils.fortimanager.common import FAIL_SOCKET_MSG
 
 
@@ -379,13 +380,12 @@ def main():
             connection.set_option('access_token', module.params['access_token'])
 
         fos = FortiOSHandler(connection, module, mkeyname)
-
-        {% if supports_check_mode -%}
+        versions_check_result = check_schema_versioning(fos, versioned_schema, "{{path}}_{{name}}")
+        {% if supports_check_mode %}
         is_error, has_changed, result = fortios_{{path}}(module.params, fos, module.check_mode)
-        {% else -%}
+        {% else %}
         is_error, has_changed, result = fortios_{{path}}(module.params, fos)
-        {% endif -%}
-        versions_check_result = connection.get_system_version()
+        {% endif %}
     else:
         module.fail_json(**FAIL_SOCKET_MSG)
 

--- a/galaxy_templates/collection/plugins/httpapi/fortios.py
+++ b/galaxy_templates/collection/plugins/httpapi/fortios.py
@@ -195,6 +195,8 @@ class HttpApi(HttpApiBase):
         """
         retrieve the system status of fortigate device
         """
+        if self._system_version:
+            return
         url = '/api/v2/cmdb/system/interface?vdom=root&action=schema'
         status, result = self.send_request(url=url)
         self.log('update sys ver: ' + str(status) + ' len=' + str(len(to_text(result))))
@@ -204,16 +206,5 @@ class HttpApi(HttpApiBase):
         self.log('ansible version: %s' % (self._ansible_fos_version))
 
     def get_system_version(self):
-        if not self._system_version:
-            raise Exception('Wrong calling stack, httpapi must login!')
-        system_version_words = self._system_version.split('.')
-        ansible_version_words = self._ansible_fos_version.split('.')
-        result = dict()
-        result['system_version'] = self._system_version
-        result['ansible_collection_version'] = self._ansible_fos_version + ' (galaxy: %s)' % (self._ansible_galaxy_version)
-        result['matched'] = system_version_words[0] == ansible_version_words[0] and system_version_words[1] == ansible_version_words[1]
-        if not result['matched']:
-            result['message'] = 'Please follow steps in FortiOS versioning notes: https://ansible-galaxy-fortios-docs.readthedocs.io/en/latest/version.html'
-        else:
-            result['message'] = 'versions match'
-        return result
+        self.update_system_version()
+        return self._system_version


### PR DESCRIPTION
testbed:
```
fortigate03: FOS 6.4.0
fortigate04: FOS 6.2.0
```

playbook:
```
- hosts: fortigates
  connection: httpapi
  collections:
  - fortinet.fortios
  vars:
   vdom: "root"
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
   - name: Configure Firewall Schedule Recurring
     fortios_firewall_schedule_recurring:
        vdom:  "{{ vdom }}"
        state: "present"
        access_token: "{{ fortios_access_token }}"
        firewall_schedule_recurring:
            name: 'always-TODELETE'
            day:
             - sunday
             - monday
            start: "00:00"
            end: ""
```

for demo, we did steps below:
we modify versioning information for `sunday` and `monday` in source module file:

```
        "day": {
            "multiple_values": True,
            "type": "list",
            "options": [
                {
                    "value": "sunday",
                    "revisions": {
                        "v6.2.0": False,
                        "v6.0.0": True,
                        "v6.4.0": True
                    }
                },
                {
                    "value": "monday",
                    "revisions": {
                        "v6.2.0": True,
                        "v6.0.0": True,
                        "v6.4.0": False
                    }
                },
```

the dump the checking result:
for fortigate03,
```
    "version_check_warning": {
        "matched": false,
        "mismatches": [
            "option day.[monday] not supported since v6.2.0"
        ],
        "system_version": "v6.4.0"
    }
```

for fortigate04:
```
    "version_check_warning": {
        "matched": false,
        "mismatches": [
            "option day.[sunday] not supported since v6.0.0, before v6.4.0"
        ],
        "system_version": "v6.2.0"
    }
```
