### PR TITLE
fix module utility code for movable modules

### DIFF
--- a/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
+++ b/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
@@ -218,7 +218,10 @@ def check_schema_versioning(fos, versioned_schema, top_level_param):
     system_version = fos._conn.get_system_version()
     params = fos._module.params[top_level_param]
     results['system_version'] = system_version
-
+    if not params:
+        # in case no top level parameters are given.
+        # see module: fortios_firewall_policy
+        return results
     module_revisions = versioned_schema['revisions']
     module_matched = __check_version(module_revisions, system_version)
     if module_matched['supported'] is False:


### PR DESCRIPTION
```
$cat fortios_firewall_policy.yml
- hosts: fortigate03
  connection: httpapi
  collections:
  - fortinet.fortios
  vars:
   vdom: "root"
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
   - name: Move Firewall Policy
     fortios_firewall_policy:
        vdom:  "{{ vdom }}"
        access_token: "{{ fortios_access_token }}"
        action: 'move'
        self: 1
        after: 2
```

result:
```
changed: [fortigate03] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "access_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "action": "move",
            "after": "2",
            "before": null,
            "firewall_policy": null,
            "self": "1",
            "state": null,
            "vdom": "root"
        }
    },
    "meta": {
        "action": "move",
        "build": 1579,
        "http_method": "PUT",
        "http_status": 200,
        "mkey": 1,
        "name": "policy",
        "old_revision": "68bfda96bc57830c4a885194b6aab897",
        "path": "firewall",
        "revision": "81edc6d4396f751226a7a8c8667b16a5",
        "revision_changed": true,
        "serial": "FGVM02TM20012347",
        "status": "success",
        "vdom": "root",
        "version": "v6.4.0"
    }
}
```