### PR TITLE
fix the exception that a parameter semantics change that module can n…

### DIFF
--- a/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
+++ b/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
@@ -110,7 +110,20 @@ def schema_to_module_spec(schema):
             assert(False)
         rdata['required'] = False
         if 'options' in schema:
-            rdata['choices'] = [option['value'] for option in schema['options']]
+            # see mantis #0690570, if the semantic meaning changes, remove choices as well
+            # also see accept_auth_by_cert of module fortios_system_csf.
+            param_semantic_changed = False
+            for ver in schema['revisions']:
+                if not schema['revisions']:
+                    continue
+                for option in schema['options']:
+                    if ver not in option['revisions']:
+                        param_semantic_changed = True
+                        break
+                if param_semantic_changed:
+                    break
+            if not param_semantic_changed:
+                rdata['choices'] = [option['value'] for option in schema['options']]
     else:
         assert(False)
     return rdata


### PR DESCRIPTION
…ot accept other values

```
$cat sdn_firewall_address.yml
---
- hosts: fortigate03
  connection: httpapi
  collections:
    - fortinet.fortios
  vars:
   vdom: "root"
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
   sdn:
      name: AWS_EAST
      type: aws
      access_key: access_key
      secret_key: secret_key
      region: us-east-1
      vpc_id: vpc_id
   fw_addr:
      name: aws_tag_private_web
      type: dynamic
      sdn: "AWS"
      filter: "Tag.Name=PrivateCloudWebServer"

  tasks:
    - name: Configure AWS connector
      fortinet.fortios.fortios_system_sdn_connector:
        state: "present"
        access_token: "{{ fortios_access_token }}"
        system_sdn_connector:
          name: "{{ sdn.name }}"
          type: "{{ sdn.type }}"
          access_key: "{{ sdn.access_key }}"
          secret_key: "{{ sdn.secret_key }}"
          region: "{{ sdn.region }}"
          vpc_id: "{{ sdn.vpc_id }}"

    - name: Configure address with sdn
      fortinet.fortios.fortios_firewall_address:
        state: "present"
        access_token: "{{ fortios_access_token }}"
        firewall_address:
          name: "{{ fw_addr.name }}"
          type: "{{ fw_addr.type }}"
          sdn: "{{ sdn.name }}"
          filter: "{{ fw_addr.filter }}"
```

`sdn` of module `fortios_firewall_policy` is now adaptive. 
in FOS 6.0, you can continue to use predefined `aci, aws, azure, gcp, nsx, nuage, oci, openstack`
in FOS 6.2 or 6.4, you can specify a custom string(sdn controller's name)

