### PR TITLE
explicit logging option: doc part

### DIFF
--- a/ansible_templates/doc.j2
+++ b/ansible_templates/doc.j2
@@ -124,6 +124,12 @@ options:
               Generated from GUI of Fortigate.
         type: str
         required: false
+    enable_log:
+        description:
+            - Enable/Disable logging for task.
+        type: bool
+        required: false
+        default: false
     vdom:
         description:
             - Virtual domain, among those defined previously. A vdom is a

--- a/galaxy_templates/sphinx_document/version.rst
+++ b/galaxy_templates/sphinx_document/version.rst
@@ -34,6 +34,7 @@ compatibility issues.
 +---------------+---------------------+----------------+-----------------------------------------------------------------+
 | 6.4.0         | 1.1.7 ``latest``    | 2020/12/21     | ``ansible-galaxy collection install fortinet.fortios:1.1.7``    |
 +---------------+---------------------+----------------+-----------------------------------------------------------------+
+
 **Note**: Use ``-f`` option (i.e.
 ``ansible-galaxy collection install -f fortinet.fortios:x.x.x``) to
 renew your existing local installation.


### PR DESCRIPTION
to avoid any permission issue, especially in Ansible Tower, logging must be disabled someway.
there is an issue which is tracking this.
https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/91

by default logging is disabled.


usage:

```
- hosts: fortigate03
  connection: httpapi
  collections:
  - fortinet.fortios
  vars:
   vdom: "root"
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
   - name: Configure Firewall Schedule Recurring
     fortios_firewall_schedule_recurring:
        vdom:  "{{ vdom }}"
        enable_log: True
        state: "present"
        access_token: "{{ fortios_access_token }}"
        firewall_schedule_recurring:
            name: 'always-TODELETE'
            day:
             - sunday
             - monday
            start: "00:00"
            end: ""
```