### PR TITLE
build document for non-get monitor API

### DIFF
--- a/ansible_templates/monitor.rst.j2
+++ b/ansible_templates/monitor.rst.j2
@@ -1,0 +1,155 @@
+:source: fortios_monitor.py
+
+:orphan:
+
+.. :
+
+fortios_monitor -- Ansible Module for FortiOS Monitor API.
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. versionadded:: 2.10
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Request FortiOS appliances to perform specific actions or procedures. This module contain all the FortiOS monitor API.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- install galaxy collection fortinet.fortios 
+
+
+Parameters
+----------
+
+
+.. raw:: html
+
+    <ul>
+    <li> <span class="li-head">vdom</span> - Virtual domain, among those defined previously. A vdom is a virtual instance of the FortiGate that can be configured and used as a different unit. <span class="li-normal">type: str</span> <span class="li-required">required: False</span> <span class="li-normal">default: root</span></li>
+    <li> <span class="li-head">enable_log</span> - Enable/Disable logging for task. <span class="li-normal">type: bool</span> <span class="li-required">required: False</span> <span class="li-normal">default: False</span> </li>
+    <li> <span class="li-head">access_token</span> - Token-based authentication. Generated from GUI of Fortigate. <span class="li-normal">type: str</span> <span class="li-required">required: False</span> </li>
+    <li><span class="li-head">action</span> - Action taken in FortiOS appliance. <span class="li-normal">type: str</span> <span class="li-required">choices:</span></li>
+        <li style="list-style: none;"><section class="accordion">
+        <input type="checkbox" name="collapse" id="handle2">
+        <h2 class="handle">
+            <label for="handle2"><u>Show full action list...</u></label>
+        </h2>
+        <div class="content">
+        <ul class="ul-self">
+        {% set ns = namespace(actions=[]) -%}
+        {% for action in actions -%}
+        {% set ns.actions = ns.actions + [action] -%}
+        {% endfor -%}
+        {% for action in ns.actions | sort -%}
+        <li><span class="li-head">{{action}}</span> {% if actions[action]['description'] %}- {{ actions[action]['description'] }} {% endif %}
+        {% if actions[action]['params'] != {} -%}
+            <ul class="ul-self">
+                {% for param_name in actions[action]['params'] -%}
+                    <li><span class="li-required">{{ param_name }}</span> - {{ actions[action]['params'][param_name]['description'] }} <span class="li-normal">type: {{ actions[action]['params'][param_name]['type'] }} </span> </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        </li>
+        {% endfor -%}
+        </ul>
+        </div>
+        </section>
+    <li><span class="li-head">params</span> - the parameter for each action, see definition in above list.<span class="li-normal">type: dict</span></li>
+
+
+Notes
+-----
+
+.. note::
+
+   - Different ``action`` may have different parameters, users are expected to look up them for a specific action.
+
+   - For some actions, no ``params`` are allowed to appear.
+
+   - Not all parameters are required for an action.
+
+   - This module is exclusivly for FortiOS monitor API.
+
+   - The result of API request is stored in ``results``.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+    
+ - hosts: fortigate03
+   connection: httpapi
+   collections:
+   - fortinet.fortios
+   vars:
+    vdom: "root"
+    ansible_httpapi_use_ssl: yes
+    ansible_httpapi_validate_certs: no
+    ansible_httpapi_port: 443
+   tasks:
+
+   - name: Activate FortiToken
+     fortios_monitor:
+        vdom: "{{ vdom }}"
+        access_token: "{{ fortios_access_token }}"
+        action: 'activate.user.fortitoken'
+        params:
+            tokens: '<token string>'
+
+   - name: Reboot This Device
+     fortios_monitor_fact:
+        vdom: "{{ vdom }}"
+        access_token: "{{ fortios_access_token }}"
+        action: 'reboot.system.os'
+        params:
+            event_log_message: 'Reboot Request From Ansible'
+
+
+Return Values
+-------------
+Common return values are documented: https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <ul>
+
+    <li> <span class="li-return">build</span> - Build number of the fortigate image <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: 1547</span></li>
+    <li> <span class="li-return">http_method</span> - Last method used to provision the content into FortiGate <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: GET</span></li>
+    <li> <span class="li-return">name</span> - Name of the table used to fulfill the request <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: firmware</span></li>
+    <li> <span class="li-return">path</span> - Path of the table used to fulfill the request <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: system</span></li>
+    <li> <span class="li-return">results</span> - Object list retrieved from device. <span class="li-normal">returned: always</span> <span class="li-normal">type: list</span></li>
+    <li> <span class="li-return">revision</span> - Internal revision number <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: 17.0.2.10658</span></li>
+    <li> <span class="li-return">serial</span> - Serial number of the unit <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: FGVMEVYYQT3AB5352</span></li>
+    <li> <span class="li-return">status</span> - Indication of the operation's result <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: success</span></li>
+    <li> <span class="li-return">vdom</span> - Virtual domain used <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: root</span></li>
+    <li> <span class="li-return">version</span> - Version of the FortiGate <span class="li-normal">returned: always</span> <span class="li-normal">type: str</span> <span class="li-normal">sample: v5.6.3</span></li>
+    <li> <span class="li-return">ansible_facts</span> - The list of fact subsets collected from the device <span class="li-normal">returned: always</span> <span class="li-normal">type: dict</span></li>
+    </ul>
+
+Status
+------
+
+- This module is not guaranteed to have a backwards compatible interface.
+
+
+Authors
+-------
+
+- Link Zheng (@chillancezen)
+- Jie Xue (@JieX19)
+- Hongbin Lu (@fgtdev-hblu)
+- Frank Shen (@fshen01)
+
+
+.. hint::
+    If you notice any issues in this documentation, you can create a pull request to improve it.

--- a/ansible_templates/monitor.rst.j2
+++ b/ansible_templates/monitor.rst.j2
@@ -1,10 +1,10 @@
-:source: fortios_monitor.py
+:source: fortios_monitor_config.py
 
 :orphan:
 
 .. :
 
-fortios_monitor -- Ansible Module for FortiOS Monitor API.
+fortios_monitor_config -- Ansible Module for FortiOS Monitor API.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. versionadded:: 2.10
@@ -37,11 +37,11 @@ Parameters
     <li> <span class="li-head">vdom</span> - Virtual domain, among those defined previously. A vdom is a virtual instance of the FortiGate that can be configured and used as a different unit. <span class="li-normal">type: str</span> <span class="li-required">required: False</span> <span class="li-normal">default: root</span></li>
     <li> <span class="li-head">enable_log</span> - Enable/Disable logging for task. <span class="li-normal">type: bool</span> <span class="li-required">required: False</span> <span class="li-normal">default: False</span> </li>
     <li> <span class="li-head">access_token</span> - Token-based authentication. Generated from GUI of Fortigate. <span class="li-normal">type: str</span> <span class="li-required">required: False</span> </li>
-    <li><span class="li-head">action</span> - Action taken in FortiOS appliance. <span class="li-normal">type: str</span> <span class="li-required">choices:</span></li>
+    <li><span class="li-head">selector</span> - Action taken in FortiOS appliance. <span class="li-normal">type: str</span> <span class="li-required">choices:</span></li>
         <li style="list-style: none;"><section class="accordion">
         <input type="checkbox" name="collapse" id="handle2">
         <h2 class="handle">
-            <label for="handle2"><u>Show full action list...</u></label>
+            <label for="handle2"><u>Show full selector list...</u></label>
         </h2>
         <div class="content">
         <ul class="ul-self">
@@ -71,11 +71,11 @@ Notes
 
 .. note::
 
-   - Different ``action`` may have different parameters, users are expected to look up them for a specific action.
+   - Different ``selector`` may have different parameters, users are expected to look up them in the dropdown list above..
 
-   - For some actions, no ``params`` are allowed to appear.
+   - For some selectors, no ``params`` are allowed to appear.
 
-   - Not all parameters are required for an action.
+   - Not all parameters are required for a selector.
 
    - This module is exclusivly for FortiOS monitor API.
 
@@ -99,18 +99,18 @@ Examples
    tasks:
 
    - name: Activate FortiToken
-     fortios_monitor:
-        vdom: "{{ vdom }}"
-        access_token: "{{ fortios_access_token }}"
-        action: 'activate.user.fortitoken'
+     fortios_monitor_config:
+        vdom: "root"
+        access_token: "<fortios_access_token>"
+        selector: 'activate.user.fortitoken'
         params:
             tokens: '<token string>'
 
    - name: Reboot This Device
-     fortios_monitor_fact:
-        vdom: "{{ vdom }}"
-        access_token: "{{ fortios_access_token }}"
-        action: 'reboot.system.os'
+     fortios_monitor_config:
+        vdom: "root"
+        access_token: "<fortios_access_token>"
+        selector: 'reboot.system.os'
         params:
             event_log_message: 'Reboot Request From Ansible'
 

--- a/galaxy_templates/sphinx_document/index.rst
+++ b/galaxy_templates/sphinx_document/index.rst
@@ -33,6 +33,7 @@ The FortiOS Ansible Collection provides Ansible modules for configuring FortiOS 
    modules.rst
    fact.rst
    generic.rst
+   monitor.rst
 
 .. toctree::
    :glob:

--- a/galaxy_templates/sphinx_document/index.rst
+++ b/galaxy_templates/sphinx_document/index.rst
@@ -31,9 +31,9 @@ The FortiOS Ansible Collection provides Ansible modules for configuring FortiOS 
    :maxdepth: 1
 
    modules.rst
+   monitor.rst
    fact.rst
    generic.rst
-   monitor.rst
 
 .. toctree::
    :glob:

--- a/galaxy_templates/sphinx_document/monitor.rst
+++ b/galaxy_templates/sphinx_document/monitor.rst
@@ -10,4 +10,4 @@ The Modules to build FortiOS monitor API requests to FortiOS appliances.
    :maxdepth: 1
 
 
-   fortios_monitor.rst
+   fortios_monitor_config.rst

--- a/galaxy_templates/sphinx_document/monitor.rst
+++ b/galaxy_templates/sphinx_document/monitor.rst
@@ -1,0 +1,13 @@
+Monitor Modules
+=========================================
+
+|
+
+The Modules to build FortiOS monitor API requests to FortiOS appliances.
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+
+   fortios_monitor.rst

--- a/scripts/generate_doc.py
+++ b/scripts/generate_doc.py
@@ -266,7 +266,7 @@ def generate_document(mod, dst):
     with open(dst, 'w') as f:
         f.write(ddata)
 
-except_list = ['fortios_configuration_fact.rst', 'fortios_monitor_fact.rst']
+except_list = ['fortios_configuration_fact.rst', 'fortios_monitor_fact.rst', 'fortios_monitor.rst']
 def main():
     if len(sys.argv) != 3:
         print('incomplete arguments list')

--- a/scripts/generate_doc.py
+++ b/scripts/generate_doc.py
@@ -266,7 +266,7 @@ def generate_document(mod, dst):
     with open(dst, 'w') as f:
         f.write(ddata)
 
-except_list = ['fortios_configuration_fact.rst', 'fortios_monitor_fact.rst', 'fortios_monitor.rst']
+except_list = ['fortios_configuration_fact.rst', 'fortios_monitor_fact.rst', 'fortios_monitor_config.rst']
 def main():
     if len(sys.argv) != 3:
         print('incomplete arguments list')

--- a/scripts/generate_modules.py
+++ b/scripts/generate_modules.py
@@ -443,6 +443,9 @@ def jinjaExecutor(number=None):
     from generate_modules_utility import generate_monitor_modules
     generate_monitor_modules(fgt_schema['version'])
 
+    from generate_modules_utility import generate_monitor_rst
+    generate_monitor_rst(fgt_schema['version'])
+
     print("\n\n\033[0mExecuting autopep8 ....")
     # Note this is done with popen and not with autopep8.fix_code in order to get the multiprocessig optimization, only available from CLI
     os.popen('autopep8 --aggressive --max-line-length 160 --jobs 8 --ignore E402 --in-place --recursive ' + autopep_files)

--- a/scripts/generate_modules_utility.py
+++ b/scripts/generate_modules_utility.py
@@ -135,6 +135,47 @@ def generate_monitor_modules(version):
         f.write(data)
         f.flush()
 
+def generate_monitor_rst(version):
+    file_loader = FileSystemLoader('ansible_templates')
+    env = Environment(loader=file_loader,
+                      lstrip_blocks=False, trim_blocks=False)
+    monitor_schema_file = open('monitor_schema.json').read()
+    monitor_schema = json.loads(monitor_schema_file)
+    post_api_items = dict()
+    assert('directory' in monitor_schema)
+    for api_item in monitor_schema['directory']:
+        assert('request' in api_item)
+        assert('http_method' in api_item['request'])
+        if api_item['request']['http_method'] != 'POST':
+            continue
+        path = api_item['path']
+        name = api_item['name']
+        action = api_item['action']
+        key = '%s.%s.%s' % (action, path, name)
+        if action == 'select':
+            key = '%s.%s' % (path, name)
+        assert(key not in post_api_items)
+        post_api_items[key] = api_item
+    schemas = dict()
+    for api_item_key in post_api_items:
+        api_item = post_api_items[api_item_key]
+        schemas[api_item_key] = dict()
+        schemas[api_item_key]['description'] = api_item['summary'] if 'summary' in api_item else ''
+        schemas[api_item_key]['params'] = dict()
+        if 'parameters' in api_item['request']:
+            for param in api_item['request']['parameters']:
+                param_name = param['name']
+                param_type = param['type']
+                param_desc = param['summary']
+                schemas[api_item_key]['params'][param_name] = dict()
+                schemas[api_item_key]['params'][param_name]['type'] = param_type
+                schemas[api_item_key]['params'][param_name]['description'] = param_desc
+    template = env.get_template('monitor.rst.j2')
+    data = template.render(actions=schemas)
+    output_path = 'output/' + version + '/fortios_monitor_config.rst'
+    with open(output_path, 'w') as f:
+        f.write(data)
+        f.flush()
 
 if __name__ == '__main__':
     generate_cofiguration_fact_rst()

--- a/scripts/generate_sphinx_doc
+++ b/scripts/generate_sphinx_doc
@@ -26,7 +26,7 @@ do
     cp $docfile $sphinxdoc_root/gen
 done
 
-files_to_move_upward='fortios_facts.rst fortios_configuration_fact.rst fortios_monitor_fact.rst'
+files_to_move_upward='fortios_facts.rst fortios_configuration_fact.rst fortios_monitor_fact.rst fortios_monitor.rst'
 for f in $files_to_move_upward
 do
     mv $sphinxdoc_root/gen/$f $sphinxdoc_root/

--- a/scripts/generate_sphinx_doc
+++ b/scripts/generate_sphinx_doc
@@ -26,7 +26,7 @@ do
     cp $docfile $sphinxdoc_root/gen
 done
 
-files_to_move_upward='fortios_facts.rst fortios_configuration_fact.rst fortios_monitor_fact.rst fortios_monitor.rst'
+files_to_move_upward='fortios_facts.rst fortios_configuration_fact.rst fortios_monitor_fact.rst fortios_monitor_config.rst'
 for f in $files_to_move_upward
 do
     mv $sphinxdoc_root/gen/$f $sphinxdoc_root/


### PR DESCRIPTION
demo: https://ansible-galaxy-fortios-docs.readthedocs.io/en/galaxy-2.0.0/fortios_monitor.html

notes:
 - the action name may vary.
 - the code to generate pseudo module `fortios_monitor.py` must be removed.(@JieX19 will cover this.)

