### PR TITLE
fix versioning checking for adjusted multiple-valued attributes

### DIFF
--- a/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
+++ b/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
@@ -206,9 +206,7 @@ def check_schema_versioning_internal(results, trace, schema, params, version):
                     trace.append(key_string)
                     check_schema_versioning_internal(results, trace, schema['children'][key], value, version)
                     del trace[-1]
-        else:
-            if 'options' not in schema:
-                raise AssertionError()
+        elif 'options' in schema:
             for param in params:
                 if type(param) not in [int, bool, str]:
                     raise AssertionError()


### PR DESCRIPTION
Related Issues;

- https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/114

Fixed Result:
```
changed: [fortigate04] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "access_token": null,
            "enable_log": null,
            "state": "present",
            "system_snmp_user": {
                "auth_proto": "sha",
                "auth_pwd": "XXXXXXXXXX",
                "events": null,
                "ha_direct": null,
                "name": "username",
                "notify_hosts": "10.0.0.1",
                "notify_hosts6": null,
                "priv_proto": "aes",
                "priv_pwd": "XXXXXXXXXX",
                "queries": null,
                "query_port": null,
                "security_level": "auth-priv",
                "source_ip": null,
                "source_ipv6": null,
                "status": "enable",
                "trap_lport": null,
                "trap_rport": null,
                "trap_status": null
            },
            "vdom": "root"
        }
    },
    "meta": {
        "build": 866,
        "http_method": "PUT",
        "http_status": 200,
        "mkey": "username",
        "name": "user",
        "path": "system.snmp",
        "revision": "3.0.0.9541577349506570699.1624470762",
        "serial": "FGVM02TM20012347",
        "status": "success",
        "vdom": "root",
        "version": "v6.2.0"
    }
}
```