### PR TITLE
fix the absence of non-required multi-list attribute issue in a object

### DIFF
--- a/ansible_templates/code.j2
+++ b/ansible_templates/code.j2
@@ -25,7 +25,7 @@ def filter_{{path}}_{{name}}_data(json):
 
 {% if special_attributes != [] -%}
 def flatten_single_path(data, path, index):
-    if not data or index == len(path) or not data[path[index]]:
+    if not data or index == len(path) or path[index] not in data:
         return
 
     if index == len(path) - 1:


### PR DESCRIPTION
  tasks:
  - name: Configure router bgp.
    fortios_router_bgp:
      vdom:  "{{ vdom }}"
      router_bgp:
        neighbor:
          - ip: '192.168.1.2'
            remote_as: '1112'
            #attribute_unchanged: ""
            #attribute_unchanged6: ""
          - ip: '192.168.1.1'
            remote_as: '1111'
            #attribute_unchanged: ""
            #attribute_unchanged6: ""
Before the fix: attribute_unchanged and attribute_unchanged6 have to be existing even though it's not required

After the fix: non-required multi-list attributes is optional to provide.