### PR TITLE
fix an intentional exception for listed options

### DIFF
--- a/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
+++ b/galaxy_templates/collection/plugins/module_utils/fortios/fortios.py
@@ -199,7 +199,9 @@ def check_schema_versioning_internal(results, trace, schema, params, version):
                 raise AssertionError()
             for list_item in params:
                 if type(list_item) is not dict:
-                    raise AssertionError()
+                    # Parameter inconsistency here is not covered by Ansible, we gracefully throw a warning
+                    results['mismatches'].append('option [%s]\' playload is inconsitent with schmea.' % (__concat_attribute_sequence(trace)))
+                    continue
                 for key in list_item:
                     value = list_item[key]
                     key_string = '%s(%s)' % (key, value) if type(value) in [int, bool, str] else key


### PR DESCRIPTION
testing playbook:
```
- collections:
  - fortinet.fortios
  connection: httpapi
  hosts: fortigate03
  tasks:
  - fortios_firewall_addrgrp:
      firewall_addrgrp:
        allow_routing: disable
        color: 0
        exclude: disable
        member:
        - terr_test
        name: terr_adrgrp
      state: present
    name: fortios_firewall_addrgrp
  vars:
    ansible_httpapi_port: 443
    ansible_httpapi_use_ssl: true
    ansible_httpapi_validate_certs: false
    vdom: root
```
without this patch:
```
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/tmp/ansible_fortios_firewall_addrgrp_payload_5oIRZe/ansible_fortios_firewall_addrgrp_payload.zip/ansible_collections/fortinet/fortios/plugins/modules/fortios_firewall_addrgrp.py", line 902, in <module>
  File "/tmp/ansible_fortios_firewall_addrgrp_payload_5oIRZe/ansible_fortios_firewall_addrgrp_payload.zip/ansible_collections/fortinet/fortios/plugins/modules/fortios_firewall_addrgrp.py", line 879, in main
  File "/tmp/ansible_fortios_firewall_addrgrp_payload_5oIRZe/ansible_fortios_firewall_addrgrp_payload.zip/ansible_collections/fortinet/fortios/plugins/module_utils/fortios/fortios.py", line 266, in check_schema_versioning
  File "/tmp/ansible_fortios_firewall_addrgrp_payload_5oIRZe/ansible_fortios_firewall_addrgrp_payload.zip/ansible_collections/fortinet/fortios/plugins/module_utils/fortios/fortios.py", line 202, in check_schema_versioning_internal
AssertionError
```

after this patch being applied:
```
    "version_check_warning": {
        "matched": false,
        "mismatches": [
            "option [member]' playload is inconsitent with schmea."
        ],
        "system_version": "v7.0.0"
    }
}
```